### PR TITLE
ci: run release workflow on ubuntu-latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Build and publish to Pypi


### PR DESCRIPTION
## 问题

打 tag `v3.0.0` 触发的 "Publish to Pypi" job 一直卡在 `Waiting for a runner to pick up this job...`(`Requested labels: ubuntu-20.04`)。

原因:GitHub 已经下线 `ubuntu-20.04` 托管 runner 镜像(2025 年初 brownout、约 4 月彻底移除),没有 runner 再提供该 label,job 永远排队。与代码/依赖/token 无关。

## 改动

- `.github/workflows/release.yml`: `runs-on: ubuntu-20.04` → `ubuntu-latest`

## 合并后续

该 release job 读取的是 **tag 指向 commit 里的 workflow**,所以合并本 PR 后需要把 `v3.0.0` tag 重新指向合并后的 commit 并强制推送,才能用新 runner 重新触发发布(`v3.0.0` 尚未成功发布到 PyPI,复用该 tag 与 `3.0.0` 包版本一致)。

Made with [Cursor](https://cursor.com)